### PR TITLE
Feature/clap-env-docker-devcontainer-tracing-subscriber

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "Rust",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bookworm",
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": { 
+				"resmon.show.battery": true,
+				"resmon.show.cpufreq": true
+			},
+			
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"vadimcn.vscode-lldb",
+				"mutantdino.resourcemonitor",
+				"rust-lang.rust-analyzer",
+				"tamasfe.even-better-toml",
+				"serayuzgur.crates"
+			]
+		}
+	},
+	"mounts": [
+		"source=${localEnv:HOME}/.ssh,target=/home/user/.ssh,type=bind,consistency=cached"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [53]
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "rustc --version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,8 @@
 		}
 	},
 	"mounts": [
-		"source=${localEnv:HOME}/.ssh,target=/home/user/.ssh,type=bind,consistency=cached"
+		"source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached",
+		"source=${localEnv:HOME}/.ssh,target=/home/thomas/.ssh,type=bind,consistency=cached"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,7 +216,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -362,6 +402,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -568,6 +614,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +707,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +746,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -810,8 +887,17 @@ checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -822,8 +908,14 @@ checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -954,6 +1046,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1095,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 name = "split-dns-resolver"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "env_logger",
  "futures",
  "hickory-client",
@@ -1004,7 +1106,15 @@ dependencies = [
  "serde",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1035,6 +1145,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1185,6 +1305,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1237,6 +1387,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ hickory-client = { version = "*", default-features = false, features = ["dns-ove
 hickory-proto = { version = "*", default-features = false, features = ["dns-over-https-rustls"] }
 hickory-server = { version = "*", default-features = false, features = ["dns-over-https-rustls"] }
 hickory-resolver = { version = "*", default-features = false, features = ["dns-over-https-rustls"] }
+clap = { version = "4.5.8", features = ["env", "derive"] }
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,108 +1,33 @@
 use std::error::Error;
-use std::net::SocketAddr;
-use std::{env, io};
-use futures::stream::{FuturesUnordered, StreamExt};
+
+use clap::Parser;
 use tokio::net::UdpSocket;
-use tokio::time::{timeout, Duration};
-use hickory_client::op::Message;
-use hickory_client::udp::UdpClientStream;
-use hickory_client::client::AsyncClient;
-use hickory_proto::DnsHandle;
+use tracing_subscriber::{prelude::*};
 
-const UPSTREAM_SERVERS: &[&str] = &[
-    "8.8.8.8:53",
-    "8.8.4.4:53",
-    "1.1.1.1:53",
-    "1.0.0.1:53",
-];
-
-struct Server {
-    socket: UdpSocket,
-    buf: Vec<u8>,
-    to_send: Option<(usize, SocketAddr)>,
-}
-
-impl Server {
-    async fn query_upstream_servers(
-        query_msg: Message,
-    ) -> Result<Message, Box<dyn Error>> {
-        let mut futures = FuturesUnordered::new();
-        
-        for &server in UPSTREAM_SERVERS {
-            let query_msg_clone = query_msg.clone(); // Clone query_msg for each iteration
-            let address = server.parse::<SocketAddr>()?;
-            let stream = UdpClientStream::<UdpSocket>::new(address);
-            let (client, bg) = AsyncClient::connect(stream).await?;
-            tokio::spawn(bg);
-
-            let client_future = async move {
-                let response = timeout(Duration::from_secs(2), client.send(query_msg_clone).next()).await;
-                match response {
-                    Ok(Some(Ok(resp))) => Some(resp),
-                    _ => None,
-                }
-            };
-
-            futures.push(client_future);
-        }
-
-        while let Some(response) = futures.next().await {
-            if let Some(valid_response) = response {
-                return Ok(valid_response.into_message());
-            }
-        }
-
-        Err("All upstream servers failed or returned invalid responses".into())
-    }
-
-    async fn run(self) -> Result<(), io::Error> {
-        let Server {
-            socket,
-            mut buf,
-            mut to_send,
-        } = self;
-
-        loop {
-            if let Some((_size, peer)) = to_send {
-                let query_msg = match Message::from_vec(&buf) {
-                    Ok(msg) => msg,
-                    Err(e) => {
-                        eprintln!("Failed to parse query message: {}", e);
-                        continue;
-                    }
-                };
-
-                match Self::query_upstream_servers(query_msg.clone()).await {
-                    Ok(mut response_message) => {
-                        response_message.set_header(*response_message.header().clone().set_id(query_msg.header().id()));
-                        if let Ok(response_vec) = response_message.to_vec() {
-                            let amt = socket.send_to(&response_vec, &peer).await?;
-                            println!("Sent {} bytes to {}, dns msg id: {}", amt, peer, query_msg.header().id());
-                        } else {
-                            eprintln!("Failed to serialize response message");
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!("Failed to get valid response from upstream servers: {}", e);
-                    }
-                }
-            }
-
-            to_send = Some(socket.recv_from(&mut buf).await?);
-        }
-    }
-}
+pub mod parse_args;
+pub mod server;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let addr = env::args()
-        .nth(1)
-        .unwrap_or_else(|| "0.0.0.0:8080".to_string());
+    // parse clap arguments
+    let args = parse_args::Args::parse();
+
+    // address to bind
+    let addr = format!("{}:{}", args.host, args.port);
+
+    // initialize tracing
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "split_dns_resolver=info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
 
     let socket = UdpSocket::bind(&addr).await?;
-    println!("Listening on: {}", socket.local_addr()?);
+    tracing::info!("Listening on: {}", socket.local_addr()?);
 
-    let server = Server {
+    let server = server::Server {
         socket,
         buf: vec![0; 1024],
         to_send: None,

--- a/src/parse_args.rs
+++ b/src/parse_args.rs
@@ -1,0 +1,15 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+pub struct Args {
+    /// Bind socket to this host
+    #[arg(long, env, default_value = "0.0.0.0")]
+    pub host: String,
+    /// Bind to this socket port
+    #[arg(short, long, env, default_value_t = 53)]
+    pub port: u32,
+    /// Time to live in seconds (TTL)
+    #[arg(short, long, env, default_value_t = 5 * 60)]
+    pub ttl: u32,
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,104 @@
+use futures::stream::{FuturesUnordered, StreamExt};
+use std::error::Error;
+use std::net::SocketAddr;
+use std::{io};
+
+use hickory_client::client::AsyncClient;
+use hickory_client::op::Message;
+use hickory_client::udp::UdpClientStream;
+use hickory_proto::DnsHandle;
+use tokio::net::UdpSocket;
+use tokio::time::{timeout, Duration};
+
+const UPSTREAM_SERVERS: &[&str] = &["8.8.8.8:53", "8.8.4.4:53", "1.1.1.1:53", "1.0.0.1:53"];
+
+pub struct Server {
+    pub socket: UdpSocket,
+    pub buf: Vec<u8>,
+    pub to_send: Option<(usize, SocketAddr)>,
+}
+
+impl Server {
+    pub async fn query_upstream_servers(query_msg: Message) -> Result<Message, Box<dyn Error>> {
+        let mut futures = FuturesUnordered::new();
+
+        for &server in UPSTREAM_SERVERS {
+            let query_msg_clone = query_msg.clone(); // Clone query_msg for each iteration
+            let address = server.parse::<SocketAddr>()?;
+            let stream = UdpClientStream::<UdpSocket>::new(address);
+            let (client, bg) = AsyncClient::connect(stream).await?;
+            tokio::spawn(bg);
+
+            let client_future = async move {
+                let response =
+                    timeout(Duration::from_secs(2), client.send(query_msg_clone).next()).await;
+                match response {
+                    Ok(Some(Ok(resp))) => Some(resp),
+                    _ => None,
+                }
+            };
+
+            futures.push(client_future);
+        }
+
+        while let Some(response) = futures.next().await {
+            if let Some(valid_response) = response {
+                return Ok(valid_response.into_message());
+            }
+        }
+
+        Err("All upstream servers failed or returned invalid responses".into())
+    }
+
+    pub async fn run(self) -> Result<(), io::Error> {
+        let Server {
+            socket,
+            mut buf,
+            mut to_send,
+        } = self;
+
+        loop {
+            if let Some((_size, peer)) = to_send {
+                let query_msg = match Message::from_vec(&buf) {
+                    Ok(msg) => msg,
+                    Err(e) => {
+                        tracing::error!("Failed to parse query message: {}", e);
+                        continue;
+                    }
+                };
+
+                tracing::info!("Query message: {}", query_msg.clone());
+
+                match Self::query_upstream_servers(query_msg.clone()).await {
+                    Ok(mut response_message) => {
+                        response_message.set_header(
+                            *response_message
+                                .header()
+                                .clone()
+                                .set_id(query_msg.header().id()),
+                        );
+                        if let Ok(response_vec) = response_message.to_vec() {
+                            let amt = socket.send_to(&response_vec, &peer).await?;
+                            tracing::info!(
+                                "Sent {} bytes to {}, dns msg id: {}",
+                                amt,
+                                peer,
+                                query_msg.header().id()
+                            );
+                        } else {
+                            tracing::error!("Failed to serialize response message");
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "Failed to get valid response from upstream servers: {}",
+                            e
+                        );
+                    }
+                }
+            }
+
+            to_send = Some(socket.recv_from(&mut buf).await?);
+        }
+    }
+}


### PR DESCRIPTION
# features
- proper binary arguments with clap. Supports --host, --port, --help and --version.
- (default host 0.0.0.0 and port 53)
- use tracing-subscriber instead of println and eprintln
- extract Server to server.rs